### PR TITLE
Add dependencies installation instructions for Fedora to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ These things are the majority of what most people would want to keep safe, but e
 ### Linux
 
 1. Install p7zip, adb, curl, whiptail, pv and optionally secure-delete. If you're on Debian or Ubuntu, run this command: `sudo apt update; sudo apt install p7zip-full adb curl whiptail pv secure-delete`.
+On Fedora enable the RPM Sphere repo using instructions from here: https://rpmsphere.github.io/
+then execute this command `sudo dnf install p7zip adb curl newt pv secure-delete`
 2. [Download](https://github.com/mrrfv/open-android-backup/releases/latest) the Open Android Backup bundle, which contains the script and companion app in one package. You can also grab an experimental build (heavily discouraged) by clicking on [this link](https://github.com/mrrfv/open-android-backup/archive/refs/heads/master.zip) or cloning.
 3. Enable [developer options](https://developer.android.com/studio/debug/dev-options#enable) and USB debugging on your device, then run `backup.sh` in a terminal.
 


### PR DESCRIPTION
My current distro is Fedora wanting to make it easier for anyone using the  Fedora/RHEL family of distros